### PR TITLE
added all rb ec2 instances for web, app, and db

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,7 @@ module "instance" {
   source = "./modules/ec2"
 
   instances = [
+    #SAS-INSTANCE
     {
       ami            = "ami-00beae93a2d981137"
       type           = "t2.micro"
@@ -81,6 +82,117 @@ module "instance" {
       key            = "rb"
       volume_size    = 20
       user_data      = templatefile("${path.module}/userdata/tailscale.sh", { tailscale_key = var.tailscale_key })
-    }
+    },
+    #web Instances
+    {
+      ami            = "ami-00beae93a2d981137"
+      type           = "t2.micro"
+      name           = "rb-web-use-1a"
+      subnet_id      = lookup(local.subnet_name_to_id, "rocket-bank-use-1a-web")
+      public_ipv4    = false
+      ipv6_count     = 1
+      security_group = [lookup(local.sg_name_to_id, "web-sg")]
+      key            = "rb"
+      volume_size    = 8
+      user_data      = templatefile("${path.module}/userdata/hostname.sh", { name = "rb-web-use-1a" })
+    },
+    {
+      ami            = "ami-00beae93a2d981137"
+      type           = "t2.micro"
+      name           = "rb-web-use-1b"
+      subnet_id      = lookup(local.subnet_name_to_id, "rocket-bank-use-1b-web")
+      public_ipv4    = false
+      ipv6_count     = 1
+      security_group = [lookup(local.sg_name_to_id, "web-sg")]
+      key            = "rb"
+      volume_size    = 8
+      user_data      = templatefile("${path.module}/userdata/hostname.sh", { name = "rb-web-use-1b" })
+    },
+    {
+      ami            = "ami-00beae93a2d981137"
+      type           = "t2.micro"
+      name           = "rb-web-use-1c"
+      subnet_id      = lookup(local.subnet_name_to_id, "rocket-bank-use-1c-web")
+      public_ipv4    = false
+      ipv6_count     = 1
+      security_group = [lookup(local.sg_name_to_id, "web-sg")]
+      key            = "rb"
+      volume_size    = 8
+      user_data      = templatefile("${path.module}/userdata/hostname.sh", { name = "rb-web-use-1c" })
+    },
+    #APP-INSTANCES
+    {
+      ami            = "ami-00beae93a2d981137"
+      type           = "t2.micro"
+      name           = "rb-app-use-1a"
+      subnet_id      = lookup(local.subnet_name_to_id, "rocket-bank-use-1a-app")
+      public_ipv4    = false
+      ipv6_count     = 1
+      security_group = [lookup(local.sg_name_to_id, "app-sg")]
+      key            = "rb"
+      volume_size    = 8
+      user_data      = templatefile("${path.module}/userdata/hostname.sh", { name = "rb-app-use-1a" })
+    },
+    {
+      ami            = "ami-00beae93a2d981137"
+      type           = "t2.micro"
+      name           = "rb-app-use-1b"
+      subnet_id      = lookup(local.subnet_name_to_id, "rocket-bank-use-1b-app")
+      public_ipv4    = false
+      ipv6_count     = 1
+      security_group = [lookup(local.sg_name_to_id, "app-sg")]
+      key            = "rb"
+      volume_size    = 8
+      user_data      = templatefile("${path.module}/userdata/hostname.sh", { name = "rb-app-use-1b" })
+    },
+    {
+      ami            = "ami-00beae93a2d981137"
+      type           = "t2.micro"
+      name           = "rb-app-use-1c"
+      subnet_id      = lookup(local.subnet_name_to_id, "rocket-bank-use-1c-app")
+      public_ipv4    = false
+      ipv6_count     = 1
+      security_group = [lookup(local.sg_name_to_id, "app-sg")]
+      key            = "rb"
+      volume_size    = 8
+      user_data      = templatefile("${path.module}/userdata/hostname.sh", { name = "rb-app-use-1c" })
+    },
+    #DB-INSTANCES
+    {
+      ami            = "ami-00beae93a2d981137"
+      type           = "t2.micro"
+      name           = "rb-db-use-1a"
+      subnet_id      = lookup(local.subnet_name_to_id, "rocket-bank-use-1a-db")
+      public_ipv4    = false
+      ipv6_count     = 1
+      security_group = [lookup(local.sg_name_to_id, "db-sg")]
+      key            = "rb"
+      volume_size    = 8
+      user_data      = templatefile("${path.module}/userdata/hostname.sh", { name = "rb-db-use-1a" })
+    },
+    {
+      ami            = "ami-00beae93a2d981137"
+      type           = "t2.micro"
+      name           = "rb-db-use-1b"
+      subnet_id      = lookup(local.subnet_name_to_id, "rocket-bank-use-1b-db")
+      public_ipv4    = false
+      ipv6_count     = 1
+      security_group = [lookup(local.sg_name_to_id, "db-sg")]
+      key            = "rb"
+      volume_size    = 8
+      user_data      = templatefile("${path.module}/userdata/hostname.sh", { name = "rb-db-use-1b" })
+    },
+    {
+      ami            = "ami-00beae93a2d981137"
+      type           = "t2.micro"
+      name           = "rb-db-use-1c"
+      subnet_id      = lookup(local.subnet_name_to_id, "rocket-bank-use-1c-db")
+      public_ipv4    = false
+      ipv6_count     = 1
+      security_group = [lookup(local.sg_name_to_id, "db-sg")]
+      key            = "rb"
+      volume_size    = 8
+      user_data      = templatefile("${path.module}/userdata/hostname.sh", { name = "rb-db-use-1c" })
+    },
   ]
 }

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -1,0 +1,4 @@
+output "instances" {
+  description = "EC2 INSTANCES DETAILS"
+  value       = aws_instance.ec2
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,25 @@ output "security_groups" {
   description = "SECURITY GROUP DETAILS"
   value       = module.sg.security_groups
 }
+
+output "instances" {
+  description = "EC2 INSTANCES DETAILS"
+  value = [
+    for instance in module.instance.instances : {
+      name         = instance.tags["Name"],
+      arn          = instance.arn
+      id           = instance.id
+      ipv6_address = instance.ipv6_addresses
+      ipv4_private = instance.private_ip
+      ipv4_public  = instance.public_ip
+      az           = instance.availability_zone
+      subnet       = lookup({ for sn in module.vpc.subnets : sn.ID => sn.name }, instance.subnet_id)
+      sg           = instance.security_groups
+    }
+  ]
+}
+
+output "instance_private_ips" {
+  description = "EC2 INSTANCE PRIVATE IPV4 ADDRESSES"
+  value       = [for instance in module.instance.instances : instance.private_ip]
+}

--- a/userdata/hostname.sh
+++ b/userdata/hostname.sh
@@ -1,0 +1,3 @@
+#! bin/bash
+hostnamectl set-hostname ${name}
+yum update -y


### PR DESCRIPTION
Terraform will perform the following actions:

  ### module.instance.aws_instance.ec2["rb-app-use-1a"] will be created
  + resource "aws_instance" "ec2" {
      + ami                                  = "ami-00beae93a2d981137"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = 1
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "rb"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-089e319d12a2e1d93"
      + tags                                 = {
          + "Name" = "rb-app-use-1a"
        }
      + tags_all                             = {
          + "Name" = "rb-app-use-1a"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "5ce9e7ca9c53fb064606149e3d7a2f85bf01bc4b"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = [
          + "sg-0a498de91ede519c9",
        ]

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 8
          + volume_type           = (known after apply)
        }
    }

  ### module.instance.aws_instance.ec2["rb-app-use-1b"] will be created
  + resource "aws_instance" "ec2" {
      + ami                                  = "ami-00beae93a2d981137"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = 1
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "rb"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-0809ca8873c8bd682"
      + tags                                 = {
          + "Name" = "rb-app-use-1b"
        }
      + tags_all                             = {
          + "Name" = "rb-app-use-1b"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "9d7206d47a5317e2541963ca2e0e69a05e353bba"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = [
          + "sg-0a498de91ede519c9",
        ]

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 8
          + volume_type           = (known after apply)
        }
    }

  ### module.instance.aws_instance.ec2["rb-app-use-1c"] will be created
  + resource "aws_instance" "ec2" {
      + ami                                  = "ami-00beae93a2d981137"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = 1
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "rb"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-0a603f144f07c99c5"
      + tags                                 = {
          + "Name" = "rb-app-use-1c"
        }
      + tags_all                             = {
          + "Name" = "rb-app-use-1c"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "c6e85d77f5cbc70ce3e63deb83489dbd0a33e625"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = [
          + "sg-0a498de91ede519c9",
        ]

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 8
          + volume_type           = (known after apply)
        }
    }

  ### module.instance.aws_instance.ec2["rb-db-use-1a"] will be created
  + resource "aws_instance" "ec2" {
      + ami                                  = "ami-00beae93a2d981137"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = 1
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "rb"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-0fadbaf33f9aaceec"
      + tags                                 = {
          + "Name" = "rb-db-use-1a"
        }
      + tags_all                             = {
          + "Name" = "rb-db-use-1a"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "5c48c5da057f044d4ccf69db168feeb4a8156fe1"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = [
          + "sg-0cbfebf75649b3ccf",
        ]

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 8
          + volume_type           = (known after apply)
        }
    }

  ### module.instance.aws_instance.ec2["rb-db-use-1b"] will be created
  + resource "aws_instance" "ec2" {
      + ami                                  = "ami-00beae93a2d981137"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = 1
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "rb"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-0b07576ccb9d233c3"
      + tags                                 = {
          + "Name" = "rb-db-use-1b"
        }
      + tags_all                             = {
          + "Name" = "rb-db-use-1b"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "445e9b2725d4da107da8b12958637f5c3323de67"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = [
          + "sg-0cbfebf75649b3ccf",
        ]

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 8
          + volume_type           = (known after apply)
        }
    }

  ### module.instance.aws_instance.ec2["rb-db-use-1c"] will be created
  + resource "aws_instance" "ec2" {
      + ami                                  = "ami-00beae93a2d981137"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = 1
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "rb"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-03ad69d925eb8a364"
      + tags                                 = {
          + "Name" = "rb-db-use-1c"
        }
      + tags_all                             = {
          + "Name" = "rb-db-use-1c"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "1ef6761f69167c7dc15af59e93e0eb005a4f6783"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = [
          + "sg-0cbfebf75649b3ccf",
        ]

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 8
          + volume_type           = (known after apply)
        }
    }

  ### module.instance.aws_instance.ec2["rb-web-use-1a"] will be created
  + resource "aws_instance" "ec2" {
      + ami                                  = "ami-00beae93a2d981137"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = 1
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "rb"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-0ac9b633641a16df0"
      + tags                                 = {
          + "Name" = "rb-web-use-1a"
        }
      + tags_all                             = {
          + "Name" = "rb-web-use-1a"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "f3cd160a57f37bdf09748c4588cae56aca61e8f3"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = [
          + "sg-048e440f473a14248",
        ]

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 8
          + volume_type           = (known after apply)
        }
    }

  ### module.instance.aws_instance.ec2["rb-web-use-1b"] will be created
  + resource "aws_instance" "ec2" {
      + ami                                  = "ami-00beae93a2d981137"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = 1
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "rb"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-02bf98500aff7ca7a"
      + tags                                 = {
          + "Name" = "rb-web-use-1b"
        }
      + tags_all                             = {
          + "Name" = "rb-web-use-1b"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "47af8f6f84a5baab5a0d9c3a7b6a9de07ce9d95b"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = [
          + "sg-048e440f473a14248",
        ]

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 8
          + volume_type           = (known after apply)
        }
    }

  ### module.instance.aws_instance.ec2["rb-web-use-1c"] will be created
  + resource "aws_instance" "ec2" {
      + ami                                  = "ami-00beae93a2d981137"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = 1
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "rb"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-005248b367d2a5d41"
      + tags                                 = {
          + "Name" = "rb-web-use-1c"
        }
      + tags_all                             = {
          + "Name" = "rb-web-use-1c"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "422519bebdeafbe2540944c3a15cfba0d3044bbf"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = [
          + "sg-048e440f473a14248",
        ]

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags_all              = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 8
          + volume_type           = (known after apply)
        }
    }

Plan: 9 to add, 0 to change, 0 to destroy.