### PR TITLE
added https outbound to all sg

### DIFF
--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -138,6 +138,28 @@ sg_egress_rule = [
     to_port      = 80,
     description  = "HTTP Traffic to servers in the APP SG"
   },
+  {
+    name         = "https_traffic_out_ipv4_web",
+    sg_id        = "web-sg",
+    ip_proto     = "tcp",
+    source_ipv4  = "0.0.0.0/0",
+    source_ipv6  = null,
+    source_sg_id = null,
+    from_port    = 443,
+    to_port      = 443,
+    description  = "All HTTPS IPv4 traffic out allowed"
+  },
+  {
+    name         = "https_traffic_out_ipv6_web",
+    sg_id        = "web-sg",
+    ip_proto     = "tcp",
+    source_ipv4  = null,
+    source_ipv6  = "::/0",
+    source_sg_id = null,
+    from_port    = 443,
+    to_port      = 443,
+    description  = "All HTTPS IPv6 traffic out allowed"
+  },
   #APP-SG RULES
   {
     name         = "app_to_db_pg",
@@ -164,6 +186,29 @@ sg_egress_rule = [
   {
     name         = "https_traffic_out_ipv6",
     sg_id        = "app-sg",
+    ip_proto     = "tcp",
+    source_ipv4  = null,
+    source_ipv6  = "::/0",
+    source_sg_id = null,
+    from_port    = 443,
+    to_port      = 443,
+    description  = "All HTTPS IPv6 traffic out allowed"
+  },
+  #DB-SG Rules
+  {
+    name         = "https_traffic_out_ipv4_db",
+    sg_id        = "db-sg",
+    ip_proto     = "tcp",
+    source_ipv4  = "0.0.0.0/0",
+    source_ipv6  = null,
+    source_sg_id = null,
+    from_port    = 443,
+    to_port      = 443,
+    description  = "All HTTPS IPv4 traffic out allowed"
+  },
+  {
+    name         = "https_traffic_out_ipv6_db",
+    sg_id        = "db-sg",
     ip_proto     = "tcp",
     source_ipv4  = null,
     source_ipv6  = "::/0",


### PR DESCRIPTION
Terraform will perform the following actions:

  ### module.sg.aws_vpc_security_group_egress_rule.sg_egress_rule["https_traffic_out_ipv4_db"] will be created
  + resource "aws_vpc_security_group_egress_rule" "sg_egress_rule" {
      + arn                    = (known after apply)
      + cidr_ipv4              = "0.0.0.0/0"
      + description            = "All HTTPS IPv4 traffic out allowed"
      + from_port              = 443
      + id                     = (known after apply)
      + ip_protocol            = "tcp"
      + security_group_id      = "sg-0cbfebf75649b3ccf"
      + security_group_rule_id = (known after apply)
      + tags                   = {
          + "Name" = "https_traffic_out_ipv4_db"
        }
      + tags_all               = {
          + "Name" = "https_traffic_out_ipv4_db"
        }
      + to_port                = 443
    }

  ### module.sg.aws_vpc_security_group_egress_rule.sg_egress_rule["https_traffic_out_ipv4_web"] will be created
  + resource "aws_vpc_security_group_egress_rule" "sg_egress_rule" {
      + arn                    = (known after apply)
      + cidr_ipv4              = "0.0.0.0/0"
      + description            = "All HTTPS IPv4 traffic out allowed"
      + from_port              = 443
      + id                     = (known after apply)
      + ip_protocol            = "tcp"
      + security_group_id      = "sg-048e440f473a14248"
      + security_group_rule_id = (known after apply)
      + tags                   = {
          + "Name" = "https_traffic_out_ipv4_web"
        }
      + tags_all               = {
          + "Name" = "https_traffic_out_ipv4_web"
        }
      + to_port                = 443
    }

  ### module.sg.aws_vpc_security_group_egress_rule.sg_egress_rule["https_traffic_out_ipv6_db"] will be created
  + resource "aws_vpc_security_group_egress_rule" "sg_egress_rule" {
      + arn                    = (known after apply)
      + cidr_ipv6              = "::/0"
      + description            = "All HTTPS IPv6 traffic out allowed"
      + from_port              = 443
      + id                     = (known after apply)
      + ip_protocol            = "tcp"
      + security_group_id      = "sg-0cbfebf75649b3ccf"
      + security_group_rule_id = (known after apply)
      + tags                   = {
          + "Name" = "https_traffic_out_ipv6_db"
        }
      + tags_all               = {
          + "Name" = "https_traffic_out_ipv6_db"
        }
      + to_port                = 443
    }

  ### module.sg.aws_vpc_security_group_egress_rule.sg_egress_rule["https_traffic_out_ipv6_web"] will be created
  + resource "aws_vpc_security_group_egress_rule" "sg_egress_rule" {
      + arn                    = (known after apply)
      + cidr_ipv6              = "::/0"
      + description            = "All HTTPS IPv6 traffic out allowed"
      + from_port              = 443
      + id                     = (known after apply)
      + ip_protocol            = "tcp"
      + security_group_id      = "sg-048e440f473a14248"
      + security_group_rule_id = (known after apply)
      + tags                   = {
          + "Name" = "https_traffic_out_ipv6_web"
        }
      + tags_all               = {
          + "Name" = "https_traffic_out_ipv6_web"
        }
      + to_port                = 443
    }

Plan: 4 to add, 0 to change, 0 to destroy.