### PR TITLE
added a cloudflare provider

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -108,5 +108,22 @@ variable "tailscale_key" {
   sensitive   = true
 }
 
+variable "cloudflare_api_key" {
+  description = "API key for cloudflare"
+  type        = string
+  sensitive   = true
+}
 
+variable "tevin_d_zone_id" {
+  description = "Zone id for tevin-d.com in cloudflare"
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_email" {
+  description = "Email of cloudflare account"
+  type        = string
+  sensitive   = true
+
+}
 


### PR DESCRIPTION
added a cloudflare provider to dynamically update the dns records of tevin-d.com with the lb web dns

### cloudflare_record.rb-dns-record will be created
  + resource "cloudflare_record" "rb-dns-record" {
      + allow_overwrite = false
      + created_on      = (known after apply)
      + hostname        = (known after apply)
      + id              = (known after apply)
      + metadata        = (known after apply)
      + modified_on     = (known after apply)
      + name            = "rocketbank"
      + proxiable       = (known after apply)
      + proxied         = false
      + ttl             = (known after apply)
      + type            = "CNAME"
      + value           = "rb-web-proxy-alb-1954425954.us-east-1.elb.amazonaws.com"
      + zone_id         = (sensitive value)
    }